### PR TITLE
Details page

### DIFF
--- a/components/Card/Card.tsx
+++ b/components/Card/Card.tsx
@@ -4,6 +4,7 @@ import Heading from "../atoms/BigHeader/BigHeader";
 import SmallHeading from "../atoms/SmallHeader/SmallHeader";
 import RegularText from "../atoms/RegularText/RegularText";
 import axios from "axios";
+import Link from "next/link";
 
 interface CardProps extends HTMLAttributes<HTMLDivElement> {
   application: {
@@ -32,6 +33,7 @@ export default function Card({ application, children, ...props }: CardProps) {
   return (
     <div className={styles.card} {...props}>
       <Heading>{title}</Heading>
+      <Link href={`/applications/${id}`}>LINK</Link>
       <div className={styles.companyField}>
         <SmallHeading>@</SmallHeading>
         <RegularText>{company}</RegularText>

--- a/components/Card/Card.tsx
+++ b/components/Card/Card.tsx
@@ -32,8 +32,9 @@ export default function Card({ application, children, ...props }: CardProps) {
 
   return (
     <div className={styles.card} {...props}>
-      <Heading>{title}</Heading>
-      <Link href={`/applications/${id}`}>LINK</Link>
+      <Link href={`/applications/${id}`}>
+        <Heading>{title}</Heading>
+      </Link>
       <div className={styles.companyField}>
         <SmallHeading>@</SmallHeading>
         <RegularText>{company}</RegularText>

--- a/pages/applications/[applicationId].tsx
+++ b/pages/applications/[applicationId].tsx
@@ -29,8 +29,6 @@ type Application = {
 export default function DetailsPage({
   application,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
-  console.log("details page, application", application);
-
   if (!application) {
     return (
       <main className={styles.main}>

--- a/pages/applications/[applicationId].tsx
+++ b/pages/applications/[applicationId].tsx
@@ -1,0 +1,68 @@
+import { useState, useContext } from "react";
+import styles from "./detailsPage.module.css";
+import {
+  GetServerSideProps,
+  InferGetServerSidePropsType,
+  GetServerSidePropsResult,
+} from "next";
+import axios from "axios";
+import prisma from "@/prisma/client";
+import Card from "@/components/Card/Card";
+import Heading from "@/components/atoms/BigHeader/BigHeader";
+
+type Application = {
+  id: number;
+  title: string;
+  company: string;
+  link?: string | null;
+  description?: string | null;
+  feedback?: string | null;
+  recruiter?: string;
+  location?: string;
+  language?: string;
+  applicationDate?: string;
+};
+
+export default function DetailsPage({
+  application,
+}: InferGetServerSidePropsType<typeof getServerSideProps>) {
+  console.log("details page, application", application);
+  return (
+    <main className={styles.main}>
+      <div>
+        <Heading>Details Page</Heading>
+      </div>
+    </main>
+  );
+}
+
+export const getServerSideProps: GetServerSideProps<{
+  application: Application;
+}> = async (
+  context
+): Promise<GetServerSidePropsResult<{ response: Application }>> => {
+  try {
+    const applicationId = context.params?.applicationId as string;
+    const application = await prisma.vacancy.findUnique({
+      where: {
+        id: applicationId,
+      },
+      include: {
+        tags: true,
+      },
+    });
+
+    return {
+      props: {
+        application: application,
+      },
+    };
+  } catch (error) {
+    console.log("DetailsPage: error fetching application data:", error);
+    return {
+      props: {
+        application: null,
+      },
+    };
+  }
+};

--- a/pages/applications/[applicationId].tsx
+++ b/pages/applications/[applicationId].tsx
@@ -1,15 +1,17 @@
-import { useState, useContext } from "react";
 import styles from "./detailsPage.module.css";
 import {
   GetServerSideProps,
   InferGetServerSidePropsType,
   GetServerSidePropsResult,
 } from "next";
-import axios from "axios";
 import prisma from "@/prisma/client";
-import Card from "@/components/Card/Card";
 import Heading from "@/components/atoms/BigHeader/BigHeader";
+import SmallHeading from "@/components/atoms/SmallHeader/SmallHeader";
 
+type Tag = {
+  id: number;
+  name: string;
+};
 type Application = {
   id: number;
   title: string;
@@ -21,26 +23,61 @@ type Application = {
   location?: string;
   language?: string;
   applicationDate?: string;
+  tags?: Tag[];
 };
 
 export default function DetailsPage({
   application,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   console.log("details page, application", application);
+
+  if (!application) {
+    return (
+      <main className={styles.main}>
+        <div>
+          <SmallHeading>Application not found</SmallHeading>
+        </div>
+      </main>
+    );
+  }
   return (
     <main className={styles.main}>
       <div>
-        <Heading>Details Page</Heading>
+        <Heading>{application.title}</Heading>
+        <SmallHeading>
+          {application.applicationDate && application.applicationDate}
+        </SmallHeading>
+        <SmallHeading>@ {application.company}</SmallHeading>
+        <SmallHeading>{application.link && application.link}</SmallHeading>
+        <SmallHeading>
+          {application.location && application.location}
+        </SmallHeading>
+        {application.tags && <SmallHeading>tags:</SmallHeading>}
+        {application.tags &&
+          application.tags.map((tag) => (
+            <SmallHeading key={tag.id}>- {tag.name}</SmallHeading>
+          ))}
+        <SmallHeading>{application.description}</SmallHeading>
+
+        <SmallHeading>
+          {application.recruiter && application.recruiter}
+        </SmallHeading>
+        <SmallHeading>
+          {application.language && `language(s): ${application.language}`}
+        </SmallHeading>
+        <SmallHeading>
+          {application.feedback && application.feedback}
+        </SmallHeading>
       </div>
     </main>
   );
 }
 
 export const getServerSideProps: GetServerSideProps<{
-  application: Application;
+  application: Application | null;
 }> = async (
   context
-): Promise<GetServerSidePropsResult<{ response: Application }>> => {
+): Promise<GetServerSidePropsResult<{ application: Application | null }>> => {
   try {
     const applicationId = context.params?.applicationId as string;
     const application = await prisma.vacancy.findUnique({
@@ -54,7 +91,7 @@ export const getServerSideProps: GetServerSideProps<{
 
     return {
       props: {
-        application: application,
+        application: application as Application | null,
       },
     };
   } catch (error) {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -39,8 +39,6 @@ export default function Home({
   const [tag, setTag] = useState("");
   const [tags, setTags] = useState([]);
 
-  console.log("index page- response:", response);
-
   const data = {
     title,
     description,

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -10,8 +10,13 @@ import prisma from "@/prisma/client";
 import Card from "@/components/Card/Card";
 import Heading from "@/components/atoms/BigHeader/BigHeader";
 
-type Application = {
+type Tag = {
   id: number;
+  name: string;
+};
+
+type Application = {
+  id: string;
   title: string;
   company: string;
   link?: string | null;
@@ -21,6 +26,7 @@ type Application = {
   location?: String;
   language?: String;
   applicationDate?: String;
+  tags?: Tag[];
 };
 
 export default function Home({
@@ -192,7 +198,7 @@ export const getServerSideProps: GetServerSideProps<{
 
     return {
       props: {
-        response: applications,
+        response: applications as Application[],
       },
     };
   } catch (error) {


### PR DESCRIPTION
# What this pull request does

## What

- By clicking on the title of a vacancy in the index page the user is forwarded to a Details Page
- The Details Page shows all exiting information related to a certain application

## Why

- The index page displays an overview of all submitted applications in a list of cards with summarised info, whereas the Details Page shows all information related to a selected application
- It makes the application well organised

## How

- Create a "pages/applications/[applicationId].tsx" file to host the Details Page
- In the index page, there is a link to it by clicking on the title of each application
- The Details Page uses "getServerSideProps" method to fetch the data from the specific application, with "context.params.vacancyId" (returns the id that is used in the "prisma.vacancy.findUnique( )" clause;

## Steppings to test this
- Go to the index page and click over a vacancy's title
- You shall be forwarded to the Details Page
- Check all available information regarding the selected vacancy

## Anything else


